### PR TITLE
Fix a bug in bash autocompletion

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -412,7 +412,7 @@ __git_refs_remotes ()
 __git_remotes ()
 {
 	local i IFS=$'\n' d="$(__gitdir)"
-	test -d "$d/remotes" && ls -1 "$d/remotes"
+	test -d "$d/refs/remotes" && ls -1 "$d/refs/remotes"
 	for i in $(git --git-dir="$d" config --get-regexp 'remote\..*\.url' 2>/dev/null); do
 		i="${i#remote.}"
 		echo "${i/.url*/}"


### PR DESCRIPTION
There is a bug in bash completions that makes it so that git remotes cannot be listed properly.  When listing git remotes, the wrong directory is specified, namely `.git/refs/remotes` is wrongly configured as `.git/remotes` (which I believe was the location of this directory in a previous version of git).  This results in an error in which typing `git push or` + `tab` prints out `ls: .git/remotes: No such file or directory`.  Once this pull request is merged, git remotes will have proper autocompletion in bash once again.
## before this pull request:

![gitbad](https://cloud.githubusercontent.com/assets/1197335/6108333/1f3b10fa-b040-11e4-9164-3c7769dae110.gif)
## after this pull request:

![gitgood](https://cloud.githubusercontent.com/assets/1197335/6108340/3878cad0-b040-11e4-9994-dcd5c4d62bba.gif)
